### PR TITLE
Q API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /dist/
 /QueueNado-1.0.tar.gz
 /QueueNado/
+/src_3rdparty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src
 MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
 include_directories(${GTEST_INCLUDE_DIRECTORIES})
 include_directories(${PROJECT_SOURCE_DIR}/src_3rdparty)
-message(" src_rdparty: ${PROJECT_SOURCE_DIR}/src_3rdparty")
 
 add_library(gtest_170_lib ${GTEST_DIR}/src/gtest-all.cc)
 set_target_properties(gtest_170_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ file(GLOB SRC_FILES ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.hpp ${PROJECT_SRC}/*.cpp
  
 # Create the QueueNado library
 include_directories(${PROJECT_SRC})
-include_directories(${PROJECT_SRC}/../src_3rdparty)
+include_directories(${PROJECT_SOURCE_DIR}/src_3rdparty)
 
 add_library(${LIBRARY_TO_BUILD} SHARED  ${SRC_FILES})
 SET(QueueNado_VERSION_STRING ${VERSION})
@@ -107,8 +107,8 @@ set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
 set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
 MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
 include_directories(${GTEST_INCLUDE_DIRECTORIES})
-include_directories(${PROJECT_SRC}/../src_3rdparty)
-message(" src_rdparty: ${PROJECT_SRC}/../src_3rdparty")
+include_directories(${PROJECT_SOURCE_DIR}/src_3rdparty)
+message(" src_rdparty: ${PROJECT_SOURCE_DIR}/src_3rdparty")
 
 add_library(gtest_170_lib ${GTEST_DIR}/src/gtest-all.cc)
 set_target_properties(gtest_170_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
@@ -134,5 +134,5 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
    #   usage:   make package
    #   Check the output result and install accordingly.
    # ==========================================================================
-   INCLUDE (${PROJECT_SRC}/../CPackLists.txt)
+   INCLUDE (${PROJECT_SOURCE_DIR}/CPackLists.txt)
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ list(APPEND LIBS ${BOOST_SYSTEM})
 find_library(FILEIO FileIO PATHS /usr/local/probe/lib )
 list(APPEND LIBS ${FILEIO})
 
-
 find_library(CQueueNado czmq PATHS /usr/local/probe/lib )
 list(APPEND LIBS ${CQueueNado})
 
@@ -91,6 +90,8 @@ file(GLOB SRC_FILES ${PROJECT_SRC}/*.h ${PROJECT_SRC}/*.hpp ${PROJECT_SRC}/*.cpp
  
 # Create the QueueNado library
 include_directories(${PROJECT_SRC})
+include_directories(${PROJECT_SRC}/../src_3rdparty)
+
 add_library(${LIBRARY_TO_BUILD} SHARED  ${SRC_FILES})
 SET(QueueNado_VERSION_STRING ${VERSION})
 MESSAGE("VERSION: ${VERSION}")
@@ -106,6 +107,9 @@ set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
 set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
 MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
 include_directories(${GTEST_INCLUDE_DIRECTORIES})
+include_directories(${PROJECT_SRC}/../src_3rdparty)
+message(" src_rdparty: ${PROJECT_SRC}/../src_3rdparty")
+
 add_library(gtest_170_lib ${GTEST_DIR}/src/gtest-all.cc)
 set_target_properties(gtest_170_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
 enable_testing(true)

--- a/packaging/QueueNado.spec
+++ b/packaging/QueueNado.spec
@@ -30,7 +30,6 @@ unzip -u gtest-1.7.0.zip
 cd ..
 sh scripts/getLibraries
 
-
 if [ "%{buildtype}" == "-DUSE_LR_DEBUG=OFF"  ]; then
    /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION:STRING=%{version}.%{buildnumber} \
       -DCMAKE_CXX_COMPILER_ARG1:STRING=' -std=c++14 -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wall -fPIC -Ofast -m64 -isystem/usr/local/gcc/include -isystem/usr/local/probe/include -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/gcc/lib64 ' \

--- a/packaging/QueueNado.spec
+++ b/packaging/QueueNado.spec
@@ -28,6 +28,8 @@ rm -f  CMakeCache.txt
 cd 3rdparty
 unzip -u gtest-1.7.0.zip
 cd ..
+sh scripts/getLibraries
+
 
 if [ "%{buildtype}" == "-DUSE_LR_DEBUG=OFF"  ]; then
    /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION:STRING=%{version}.%{buildnumber} \
@@ -48,6 +50,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/local/probe/lib
 cp -rfd lib%{name}.so* $RPM_BUILD_ROOT/usr/local/probe/lib
 mkdir -p $RPM_BUILD_ROOT/usr/local/probe/include
 cp src/*.h $RPM_BUILD_ROOT/usr/local/probe/include
+cp -r src_3rdparty/q $RPM_BUILD_ROOT/usr/local/probe/include/.
 rm -f $RPM_BUILD_ROOT/usr/local/probe/include/QueueNadoMacros.h
 
 %post

--- a/scripts/buildDev.sh
+++ b/scripts/buildDev.sh
@@ -26,16 +26,22 @@ PATH=/usr/local/probe/bin:$PATH
 rm -f  CMakeCache.txt
 cd 3rdparty
 unzip -u gtest-1.7.0.zip
-cd ../build
+cd ..
+sh scripts/getLibraries
+cd build
 
 
 
 if [ "$BUILD_TYPE" == "-DUSE_DEBUG_COVERAGE=OFF" ]; then
    echo "buildtype: -DUSE_DEBUG_COVERAGE=OFF --> PRODUCTION for version: $VERSION"
-   /usr/local/probe/bin/cmake -DVERSION=$VERSION -DCMAKE_CXX_COMPILER_ARG1:STRING=' -fPIC -Ofast -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++ ..
+  /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION:STRING=$VERSION \
+      -DCMAKE_CXX_COMPILER_ARG1:STRING=' -std=c++14 -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wall -fPIC -Ofast -m64 -isystem/usr/local/gcc/include -isystem/usr/local/probe/include -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/gcc/lib64 ' \
+      -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER=/usr/local/gcc/bin/g++ ..
 elif [ "$BUILD_TYPE" == "-DUSE_DEBUG_COVERAGE=ON" ]; then
    echo "buildtype: -DUSE_DEBUG_COVERAGE=ON for version: $VERSION";
-   /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION=$VERSION  -DCMAKE_CXX_COMPILER_ARG1:STRING=' -Wall -Werror -g -gdwarf-2 -fprofile-arcs -ftest-coverage -O0 -fPIC -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++ ..
+  /usr/local/probe/bin/cmake -DVERSION:STRING=$VERSION \
+      -DCMAKE_CXX_COMPILER_ARG1:STRING=' -std=c++14 -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -Wall -g -gdwarf-2 -O0 -fPIC -m64 -isystem/usr/local/gcc/include -isystem/usr/local/probe/include -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/gcc/lib64 ' \
+      -DCMAKE_CXX_COMPILER=/usr/local/gcc/bin/g++ ..
 else
    echo "unknown buildtype $BUILD_TYPE"
    exit 1

--- a/scripts/getLibraries
+++ b/scripts/getLibraries
@@ -30,7 +30,7 @@ GitRepeat() {
 
 rm -rf Q
 rm -rf src_3rdparty/q
-GitRepeat KjellKod Q setup
+GitRepeat KjellKod Q SFINAE 
 mkdir -p src_3rdparty
 mv Q/src/* src_3rdparty/.
 rm -rf Q

--- a/scripts/getLibraries
+++ b/scripts/getLibraries
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+GitRepeat() {
+   userName=$1
+   repoName=$2
+   branch=$3
+
+   fullRepo="https://github.com/$userName/$repoName.git"
+   tryCount=1
+   stopFlag=1
+   if [ ! -d "$repoName" ]; then
+      while [ $stopFlag == 1 ]; do
+         let tryCount=tryCount+1
+         timeout 60 git clone -b $branch $fullRepo
+         if [ "$?" -eq 0 ]; then
+            stopFlag=0
+         else
+            rm -rf $repoName
+            if [ "$tryCount" -gt 60 ]; then
+               echo \"git clone -b $branch $fullRepo\" failed 60 times in 60 minutes.
+               exit -60
+            fi
+            echo retrying \"git clone $fullRepo\"
+         fi
+      done
+   else
+      echo $repoName already exists.
+   fi
+}
+
+rm -rf Q
+rm -rf src_3rdparty/q
+GitRepeat KjellKod Q setup
+mkdir -p src_3rdparty
+mv Q/src/* src_3rdparty/.
+rm -rf Q
+

--- a/scripts/getLibraries
+++ b/scripts/getLibraries
@@ -30,7 +30,7 @@ GitRepeat() {
 
 rm -rf Q
 rm -rf src_3rdparty/q
-GitRepeat KjellKod Q SFINAE 
+GitRepeat KjellKod Q  master
 mkdir -p src_3rdparty
 mv Q/src/* src_3rdparty/.
 rm -rf Q

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -29,8 +29,7 @@
 
 namespace QAPI {
 // Base Queue API without pop() and push()
-// It should be mentioned the thinking of what goes where
-// it is a "controversy" whether what is tail and what is head
+// This follows the 'tail' first design on FIFO
 // http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
 // This implementation follows "pop on head", "push on tail"
    template<typename QType>

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <tuple>
+#include <memory>
+#include <TimeStats.h>
+#include <TriggerTimeStats.h>
+#include <q/spsc.hpp>
+#include <q/mpmc.hpp>
+
+/* Inspired by https://github.com/KjellKod/Q/src/q/q_api.hpp*/
+
+
+namespace QAPI {
+// Base Queue API without pop() and push()
+// It should be mentioned the thinking of what goes where
+// it is a "controversy" whether what is tail and what is head
+// http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
+// This implementation follows "pop on head", "push on tail"
+   template<typename QType>
+   struct Base {
+      Base(std::shared_ptr<QType> q)
+         : mQueueStorage(q)
+         , mQueueRef(*(q.get())) {
+      }
+      bool empty() const { return mQueueRef.empty();}
+      bool full() const { return mQueueRef.full(); }
+      size_t capacity() const { return mQueueRef.capacity(); }
+      size_t capacity_free() const { return mQueueRef.capacity_free(); }
+      size_t size() const { return mQueueRef.size(); }
+      bool lock_free() const { return mQueueRef.size(); }
+      size_t usage() const { return mQueueRef.usage(); }
+
+      std::shared_ptr<QType> mQueueStorage;
+      QType& mQueueRef;
+   };
+
+
+
+// struct with: push() + base Queue API
+   template<typename QType>
+   struct Sender : public Base<QType> {
+    public:
+      Sender(std::shared_ptr<QType> q): Base<QType>(q) {}
+      virtual ~Sender() = default;
+
+      template<typename Element>
+      bool push(Element& item) {
+         TriggerTimeStats trigger(mStats);
+         auto result = Base<QType>::mQueueRef.push(item);
+         if (!result) {
+            trigger.Skip();
+         }
+         return result;
+      }
+
+      TimeStats mStats;
+   };
+
+
+
+// struct with : pop() + base Queue API
+   template<typename QType>
+   struct Receiver : public Base<QType> {
+    public:
+      Receiver(std::shared_ptr<QType> q) :  Base<QType>(q) {}
+      virtual ~Receiver() = default;
+
+      template<typename Element>
+      bool pop(Element& item) {
+         TriggerTimeStats trigger(mStats);
+         auto result =  Base<QType>::mQueueRef.pop(item);
+         if (!result) {
+            trigger.Skip();
+         }
+         return result;
+      }
+      TimeStats mStats;
+   };  // ReceiverQ
+
+
+
+   template<typename QType, typename... Args>
+   std::pair<Sender<QType>, Receiver<QType>> CreateQueue(Args&& ... args) {
+      std::shared_ptr<QType> ptr = std::make_shared<QType>(std::forward< Args >(args)...);
+      return std::make_pair(Sender<QType> {ptr}, Receiver<QType> {ptr});
+   }
+
+   enum index {sender = 0, receiver = 1};
+} // QueueAPI
+
+
+
+
+
+
+
+

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -45,7 +45,7 @@ namespace QAPI {
       size_t capacity_free() const { return mQueueRef.capacity_free(); }
       size_t size() const { return mQueueRef.size(); }
       bool lock_free() const { return mQueueRef.size(); }
-      size_t usage() const { return mQueueRef.usage(); }
+      auto usage() const -> decltype(&QType::usage) { return mQueueRef.usage(); }
 
       std::shared_ptr<QType> mQueueStorage;
       QType& mQueueRef;

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -39,8 +39,10 @@ namespace QAPI {
       size_t capacity() const { return mQueueRef.capacity(); }
       size_t capacity_free() const { return mQueueRef.capacity_free(); }
       size_t size() const { return mQueueRef.size(); }
-      bool lock_free() const { return mQueueRef.size(); }
-      auto usage() const -> decltype(&QType::usage) { return mQueueRef.usage(); }
+      // GCC BUG:  std::atomic<size_t>{}.is_lock_free(); is not implemented in gcc 4.8.5
+      // It is implemented in later versions (gc 5.3 and newer)
+      //bool lock_free() const { return mQueueRef.lock_free(); } 
+      size_t usage() const { return mQueueRef.usage(); }
 
       std::shared_ptr<QType> mQueueStorage;
       QType& mQueueRef;

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -52,7 +52,7 @@ namespace QAPI {
 
 
 
-// struct with: push() + base Queue API
+   // push() + base Queue API
    template<typename QType>
    struct Sender : public Base<QType> {
     public:
@@ -113,7 +113,9 @@ namespace QAPI {
 
 
 
-// struct with : pop() + base Queue API
+   // pop(), wait_and_pop + base Queue API
+   // if the QType does not support wait_and_pop then 
+   // it will follow the sfinae::wrapper's wait_and_pop implementation
    template<typename QType>
    struct Receiver : public Base<QType> {
     public:

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -102,7 +102,9 @@ namespace QAPI {
 
       template <typename T, typename Element>
       int wait_and_pop (T& t, Element& e, std::chrono::milliseconds ms) {
-         // SFINAE magic happens with the '0'.  For the right call it will be deducted ot bhe
+         // SFINAE magic happens with the '0'.  
+         // For the matching call the '0' will be typed to int. 
+         // For non-matching call it will be typed to long
          return match_call(t, e, ms, 0);
       }
    } // sfinae

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -14,7 +14,6 @@
 * https://github.com/KjellKod/Q/src/q/q_api.hpp
 */
 
-
 #pragma once
 
 #include <tuple>
@@ -23,9 +22,6 @@
 #include <TriggerTimeStats.h>
 #include <q/spsc.hpp>
 #include <q/mpmc.hpp>
-
-
-
 
 namespace QAPI {
    // Base Queue API without pop() and push()
@@ -51,7 +47,6 @@ namespace QAPI {
    };
 
 
-
    // push() + base Queue API
    template<typename QType>
    struct Sender : public Base<QType> {
@@ -68,7 +63,6 @@ namespace QAPI {
          }
          return result;
       }
-
       TimeStats mStats;
    };
 
@@ -109,7 +103,7 @@ namespace QAPI {
          // SFINAE magic happens with the '0'.  For the right call it will be deducted ot bhe
          return match_call(t, e, ms, 0);
       }
-   }
+   } // sfinae
 
 
 
@@ -141,11 +135,8 @@ namespace QAPI {
          }
          return result;
       }
-
-
       TimeStats mStats;
-   };  // ReceiverQ
-
+   };  
 
 
    template<typename QType, typename... Args>
@@ -156,11 +147,3 @@ namespace QAPI {
 
    enum index {sender = 0, receiver = 1};
 } // QueueAPI
-
-
-
-
-
-
-
-

--- a/src/QAPI.h
+++ b/src/QAPI.h
@@ -28,10 +28,10 @@
 
 
 namespace QAPI {
-// Base Queue API without pop() and push()
-// This follows the 'tail' first design on FIFO
-// http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
-// This implementation follows "pop on head", "push on tail"
+   // Base Queue API without pop() and push()
+   // This follows the 'tail' first design on FIFO
+   // http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
+   // This implementation follows "pop on head", "push on tail"
    template<typename QType>
    struct Base {
       Base(std::shared_ptr<QType> q)

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -53,7 +53,7 @@ TEST(Performance, SPSC_Fixed_CircularFifo_Smaller) {
 
 TEST(Performance, MPMC_1_to_1) {
    using namespace std;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kAmount, std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kAmount);
    RunSPSC(queue, kAmount);
 }
 
@@ -61,13 +61,12 @@ TEST(Performance, MPMC_1_to_1) {
 TEST(Performance, MPMC_1_to_1_Smaller) {
    using namespace std;
 
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
-                std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize);
    RunSPSC(queue, kAmount);
 }
 
 
-TEST(Performance, SPSC_Flexible_30secRun_LargeData) {
+TEST(Performance, SPSC_Flexible_20secRun_LargeData) {
    using namespace std;
    auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kSmallQueueSize);
    const size_t large = 65554;
@@ -75,11 +74,11 @@ TEST(Performance, SPSC_Flexible_30secRun_LargeData) {
    EXPECT_EQ(large, data.size());
    const size_t numberOfProducers = 1;
    const size_t numberOfConsumers = 1;
-   const size_t kTimeToRunSec = 30;
+   const size_t kTimeToRunSec = 20;
    RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
 
-TEST(Performance, SPSC_Fixed_30secRun_LargeData) {
+TEST(Performance, SPSC_Fixed_20secRun_LargeData) {
    using namespace std;
    auto queue = QAPI::CreateQueue<spsc::fixed::circular_fifo<std::string, kSmallQueueSize>>();
    const size_t large = 65554;
@@ -87,34 +86,32 @@ TEST(Performance, SPSC_Fixed_30secRun_LargeData) {
    EXPECT_EQ(large, data.size());
    const size_t numberOfProducers = 1;
    const size_t numberOfConsumers = 1;
-   const size_t kTimeToRunSec = 30;
+   const size_t kTimeToRunSec = 20;
    RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
 
 
-TEST(Performance, MPMC_4_to_1_LargeData) {
+TEST(Performance, MPMC_4_to_1_20secRun_LargeData) {
    using namespace std;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
-                std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize);
    const size_t large = 65554;
    std::string data(large, 'a');
    EXPECT_EQ(large, data.size());
    const size_t numberOfProducers = 1;
    const size_t numberOfConsumers = 4;
-   const size_t kTimeToRunSec = 30;
+   const size_t kTimeToRunSec = 20;
    RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
 
-TEST(Performance, MPMC_4_to_4_LargeData) {
+TEST(Performance, MPMC_4_to_4_20secRun_LargeData) {
    using namespace std;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
-                std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize);
    const size_t large = 65554;
    std::string data(large, 'a');
    EXPECT_EQ(large, data.size());
    const size_t numberOfProducers = 4;
    const size_t numberOfConsumers = 4;
-   const size_t kTimeToRunSec = 30;
+   const size_t kTimeToRunSec = 20;
    RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
 

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -37,7 +37,6 @@ TEST(Queue, ProdConsInitializationCopy) {
 TEST(Queue, BaseAPI_Flexible) {
    auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kAmount);
    auto producer = std::get<QAPI::index::sender>(queue);
-   auto consumer = std::get<QAPI::index::receiver>(queue);
    EXPECT_TRUE(producer.empty());
    EXPECT_FALSE(producer.full());
    EXPECT_EQ(kAmount, producer.capacity());

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -91,7 +91,7 @@ TEST(Performance, SPSC_Fixed_20secRun_LargeData) {
 }
 
 
-TEST(Performance, MPMC_4_to_1_20secRun_LargeData) {
+TEST(Performance, MPMC_1_to_4_20secRun_LargeData) {
    using namespace std;
    auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize);
    const size_t large = 65554;
@@ -99,6 +99,18 @@ TEST(Performance, MPMC_4_to_1_20secRun_LargeData) {
    EXPECT_EQ(large, data.size());
    const size_t numberOfProducers = 1;
    const size_t numberOfConsumers = 4;
+   const size_t kTimeToRunSec = 20;
+   RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
+}
+
+TEST(Performance, MPMC_4_to_1_20secRun_LargeData) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize);
+   const size_t large = 65554;
+   std::string data(large, 'a');
+   EXPECT_EQ(large, data.size());
+   const size_t numberOfProducers = 4;
+   const size_t numberOfConsumers = 1;
    const size_t kTimeToRunSec = 20;
    RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -16,14 +16,13 @@
 #include <thread>
 #include <algorithm>
 
+using namespace QApiTests;
+
 namespace {
    const size_t kAmount = 1000000;
    const size_t kSmallQueueSize = 100;
 }
 
-
-
-using namespace QApiTests;
 
 TEST(Performance, SPSC_Flexible_CircularFifo) {
    auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kAmount);
@@ -45,10 +44,9 @@ TEST(Performance, SPSC_Fixed_CircularFifo) {
 
 TEST(Performance, SPSC_Fixed_CircularFifo_Smaller) {
    using namespace std;
-   auto queue = QAPI::CreateQueue < spsc::fixed::circular_fifo<string, kSmallQueueSize>> ();
+   auto queue = QAPI::CreateQueue<spsc::fixed::circular_fifo<string, kSmallQueueSize>>();
    RunSPSC(queue, kAmount);
 }
-
 
 
 TEST(Performance, MPMC_1_to_1) {

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -23,6 +23,16 @@ namespace {
    const size_t kSmallQueueSize = 100;
 }
 
+TEST(Queue, ProdConsInitializationCopy) {
+   using namespace QAPI;
+   using QType = spsc::flexible::circular_fifo<std::string>;
+   auto queue = CreateQueue<QType>(kAmount);
+    Sender<QType> sender1 = std::get<QAPI::index::sender>(queue);
+    Sender<QType> sender2(std::get<QAPI::index::sender>(queue));
+    Receiver<QType> receiver1 = std::get<QAPI::index::receiver>(queue);
+    Receiver<QType> receiver2(std::get<QAPI::index::receiver>(queue));
+}
+
 
 TEST(Queue, BaseAPI_Flexible) {
    auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kAmount);

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -45,7 +45,7 @@ TEST(Performance, SPSC_Fixed_CircularFifo) {
 
 TEST(Performance, SPSC_Fixed_CircularFifo_Smaller) {
    using namespace std;
-   auto queue = QAPI::CreateQueue < spsc::fixed::circular_fifo < string, kSmallQueueSize>> ();
+   auto queue = QAPI::CreateQueue < spsc::fixed::circular_fifo<string, kSmallQueueSize>> ();
    RunSPSC(queue, kAmount);
 }
 
@@ -67,88 +67,54 @@ TEST(Performance, MPMC_1_to_1_Smaller) {
 }
 
 
-template<typename T>
-void RunMPSC(T queue) {
-   std::atomic<bool> producerStart{false};
-   std::atomic<bool> consumerStart{false};
-
- 
+TEST(Performance, SPSC_Flexible_30secRun_LargeData) {
    using namespace std;
-   using namespace std::chrono;
+   auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kSmallQueueSize);
+   const size_t large = 65554;
+   std::string data(large, 'a');
+   EXPECT_EQ(large, data.size());
+   const size_t numberOfProducers = 1;
+   const size_t numberOfConsumers = 1;
+   const size_t kTimeToRunSec = 30;
+   RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
+}
 
-   auto producer = std::get <QAPI::index::sender>(queue);
-   auto consumer = std::get <QAPI::index::receiver>(queue);
-
-
-   auto start1 = 0;
-   auto stop1 = kAmount / 4 * 1;
-
-   auto start2 = kAmount / 4 * 1;
-   auto stop2 = kAmount / 4 * 2;
-
-   auto start3 = kAmount / 4 * 2;
-   auto stop3 = kAmount / 4 * 3;
-
-   auto start4 = kAmount / 4 * 3;
-   auto stop4 = kAmount / 4 * 4;
-
-   auto start0 = 0;
-   auto stop0 = kAmount;
-
-   auto t1 = high_resolution_clock::now();
-
-   auto p1 = std::async(std::launch::async, Push<decltype(producer)>, producer, start1, stop1,
-                        std::ref(producerStart), std::ref(consumerStart));
-   auto p2 = std::async(std::launch::async, Push<decltype(producer)>, producer, start2, stop2,
-                        std::ref(producerStart), std::ref(consumerStart));
-   auto p3 = std::async(std::launch::async, Push<decltype(producer)>, producer, start3, stop3,
-                        std::ref(producerStart), std::ref(consumerStart));
-   auto p4 = std::async(std::launch::async, Push<decltype(producer)>, producer, start4, stop4,
-                        std::ref(producerStart), std::ref(consumerStart));
-   auto c0 = std::async(std::launch::async, Get<decltype(consumer)>, consumer, start0, stop0,
-                        std::ref(producerStart), std::ref(consumerStart));
-
-
-   auto e1 = p1.get();
-   auto e2 = p2.get();
-   auto e3 = p3.get();
-   auto e4 = p4.get();
-   auto received =  c0.get();
-   auto t2 = high_resolution_clock::now();
-
-   auto us = duration_cast<microseconds>( t2 - t1 ).count();
-   std::cout << "Push - Pull #" << kAmount << " items in: " << us  << " us" << std::endl;
-   std::cout << "Average: " << 1000 * ((float)us / (float) kAmount) << " ns" << std::endl;
-
-
-   std::vector<std::string> eAll;
-   //eAll.reserve(kAmount);
-   eAll.insert(eAll.end(), e1.begin(), e1.end());
-   e1.clear();
-   eAll.insert(eAll.end(), e2.begin(), e2.end());
-   e2.clear();
-   eAll.insert(eAll.end(), e3.begin(), e3.end());
-   e3.clear();
-   eAll.insert(eAll.end(), e4.begin(), e4.end());
-   e4.clear();
-
-   std::sort(eAll.begin(), eAll.end());
-   std::sort(received.begin(), received.end());
-   EXPECT_EQ(kAmount, received.size());
-   EXPECT_EQ(eAll, received);
+TEST(Performance, SPSC_Fixed_30secRun_LargeData) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<spsc::fixed::circular_fifo<std::string, kSmallQueueSize>>();
+   const size_t large = 65554;
+   std::string data(large, 'a');
+   EXPECT_EQ(large, data.size());
+   const size_t numberOfProducers = 1;
+   const size_t numberOfConsumers = 1;
+   const size_t kTimeToRunSec = 30;
+   RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
 
 
-TEST(Performance, MPMC_4_to_1) {
-   using namespace std;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kAmount,
-                std::chrono::milliseconds(1));
-   RunMPSC(queue);
-}
-
-TEST(Performance, MPMC_4_to_1_Smaller) {
+TEST(Performance, MPMC_4_to_1_LargeData) {
    using namespace std;
    auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
                 std::chrono::milliseconds(1));
-   RunMPSC(queue);
+   const size_t large = 65554;
+   std::string data(large, 'a');
+   EXPECT_EQ(large, data.size());
+   const size_t numberOfProducers = 1;
+   const size_t numberOfConsumers = 4;
+   const size_t kTimeToRunSec = 30;
+   RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
 }
+
+TEST(Performance, MPMC_4_to_4_LargeData) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
+                std::chrono::milliseconds(1));
+   const size_t large = 65554;
+   std::string data(large, 'a');
+   EXPECT_EQ(large, data.size());
+   const size_t numberOfProducers = 4;
+   const size_t numberOfConsumers = 4;
+   const size_t kTimeToRunSec = 30;
+   RunMPMC(queue, data, numberOfProducers, numberOfConsumers, kTimeToRunSec);
+}
+

--- a/test/QApiTests.cpp
+++ b/test/QApiTests.cpp
@@ -1,0 +1,154 @@
+/* Not any company's property but Public-Domain
+* Do with source-code as you will. No requirement to keep this
+* header if need to use it/change it/ or do whatever with it
+*
+* Note that there is No guarantee that this code will work
+* and I take no responsibility for this code and any problems you
+* might get if using it.
+*
+* Modified from original test at:  https://github.com/KjellKod/Q
+*/
+
+#include "QAPI.h"
+#include "QApiTests.h"
+#include <q/spsc.hpp>
+#include <q/mpmc.hpp>
+#include <thread>
+#include <algorithm>
+
+namespace {
+   const size_t kAmount = 1000000;
+   const size_t kSmallQueueSize = 100;
+}
+
+
+
+using namespace QApiTests;
+
+TEST(Performance, SPSC_Flexible_CircularFifo) {
+   auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kAmount);
+   RunSPSC(queue, kAmount);
+}
+
+TEST(Performance, SPSC_Flexible_CircularFifo_Smaller) {
+   auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(kSmallQueueSize);
+   RunSPSC(queue, kAmount);
+}
+
+
+TEST(Performance, SPSC_Fixed_CircularFifo) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<spsc::fixed::circular_fifo<string, kAmount>>();
+   RunSPSC(queue, kAmount);
+}
+
+
+TEST(Performance, SPSC_Fixed_CircularFifo_Smaller) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue < spsc::fixed::circular_fifo < string, kSmallQueueSize>> ();
+   RunSPSC(queue, kAmount);
+}
+
+
+
+TEST(Performance, MPMC_1_to_1) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kAmount, std::chrono::milliseconds(1));
+   RunSPSC(queue, kAmount);
+}
+
+
+TEST(Performance, MPMC_1_to_1_Smaller) {
+   using namespace std;
+
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
+                std::chrono::milliseconds(1));
+   RunSPSC(queue, kAmount);
+}
+
+
+template<typename T>
+void RunMPSC(T queue) {
+   std::atomic<bool> producerStart{false};
+   std::atomic<bool> consumerStart{false};
+
+ 
+   using namespace std;
+   using namespace std::chrono;
+
+   auto producer = std::get <QAPI::index::sender>(queue);
+   auto consumer = std::get <QAPI::index::receiver>(queue);
+
+
+   auto start1 = 0;
+   auto stop1 = kAmount / 4 * 1;
+
+   auto start2 = kAmount / 4 * 1;
+   auto stop2 = kAmount / 4 * 2;
+
+   auto start3 = kAmount / 4 * 2;
+   auto stop3 = kAmount / 4 * 3;
+
+   auto start4 = kAmount / 4 * 3;
+   auto stop4 = kAmount / 4 * 4;
+
+   auto start0 = 0;
+   auto stop0 = kAmount;
+
+   auto t1 = high_resolution_clock::now();
+
+   auto p1 = std::async(std::launch::async, Push<decltype(producer)>, producer, start1, stop1,
+                        std::ref(producerStart), std::ref(consumerStart));
+   auto p2 = std::async(std::launch::async, Push<decltype(producer)>, producer, start2, stop2,
+                        std::ref(producerStart), std::ref(consumerStart));
+   auto p3 = std::async(std::launch::async, Push<decltype(producer)>, producer, start3, stop3,
+                        std::ref(producerStart), std::ref(consumerStart));
+   auto p4 = std::async(std::launch::async, Push<decltype(producer)>, producer, start4, stop4,
+                        std::ref(producerStart), std::ref(consumerStart));
+   auto c0 = std::async(std::launch::async, Get<decltype(consumer)>, consumer, start0, stop0,
+                        std::ref(producerStart), std::ref(consumerStart));
+
+
+   auto e1 = p1.get();
+   auto e2 = p2.get();
+   auto e3 = p3.get();
+   auto e4 = p4.get();
+   auto received =  c0.get();
+   auto t2 = high_resolution_clock::now();
+
+   auto us = duration_cast<microseconds>( t2 - t1 ).count();
+   std::cout << "Push - Pull #" << kAmount << " items in: " << us  << " us" << std::endl;
+   std::cout << "Average: " << 1000 * ((float)us / (float) kAmount) << " ns" << std::endl;
+
+
+   std::vector<std::string> eAll;
+   //eAll.reserve(kAmount);
+   eAll.insert(eAll.end(), e1.begin(), e1.end());
+   e1.clear();
+   eAll.insert(eAll.end(), e2.begin(), e2.end());
+   e2.clear();
+   eAll.insert(eAll.end(), e3.begin(), e3.end());
+   e3.clear();
+   eAll.insert(eAll.end(), e4.begin(), e4.end());
+   e4.clear();
+
+   std::sort(eAll.begin(), eAll.end());
+   std::sort(received.begin(), received.end());
+   EXPECT_EQ(kAmount, received.size());
+   EXPECT_EQ(eAll, received);
+}
+
+
+TEST(Performance, MPMC_4_to_1) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kAmount,
+                std::chrono::milliseconds(1));
+   RunMPSC(queue);
+}
+
+TEST(Performance, MPMC_4_to_1_Smaller) {
+   using namespace std;
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<string>>(kSmallQueueSize,
+                std::chrono::milliseconds(1));
+   RunMPSC(queue);
+}

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -127,8 +127,8 @@ namespace QApiTests {
 
       using namespace std;
       using namespace chrono;
-      auto producer = std::get <QAPI::index::sender>(queue);
-      auto consumer = std::get <QAPI::index::receiver>(queue);
+      auto producer = std::get<QAPI::index::sender>(queue);
+      auto consumer = std::get<QAPI::index::receiver>(queue);
 
       auto t1 = high_resolution_clock::now();
       size_t start = 0;
@@ -161,8 +161,8 @@ namespace QApiTests {
 
       using namespace std;
       using namespace std::chrono;
-      auto producer = std::get <QAPI::index::sender>(queue);
-      auto consumer = std::get <QAPI::index::receiver>(queue);
+      auto producer = std::get<QAPI::index::sender>(queue);
+      auto consumer = std::get<QAPI::index::receiver>(queue);
       std::vector<std::future<size_t>> producerResult;
       producerResult.reserve(numberProducers);
 
@@ -201,8 +201,13 @@ namespace QApiTests {
          amountConsumed += result.get();
       }
 
+
+      // amoundProduced >= amountConsumed
+      // amountProduced <= amountConsumed + 100
+      EXPECT_TRUE(amountProduced >= amountConsumed);
+      EXPECT_TRUE(amountProduced <= amountConsumed + producer.capacity());
+
       auto elapsedTimeSec = elapsedRun.ElapsedSec();
-      EXPECT_GE(amountConsumed + 100, amountProduced);
       std::cout << "Transaction/s: "
                 << amountConsumed / elapsedTimeSec << std::endl;
       std::cout << "Transaction/s per consumer: "

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -168,15 +168,17 @@ namespace QApiTests {
 
       for (size_t i = 0; i < numberProducers; ++i) {
          producerResult.emplace_back(std::async(std::launch::async, PushUntil<decltype(producer)>,
-                                                producer, data, numberProducers, std::ref(producerCount),
-                                                std::ref(consumerCount), std::ref(producerStop)));
+                                                producer, data, numberProducers, 
+                                                std::ref(producerCount), std::ref(consumerCount), 
+                                                std::ref(producerStop)));
       }
       std::vector<std::future<size_t>> consumerResult;
       consumerResult.reserve(numberConsumers);
       for (size_t i = 0; i < numberProducers; ++i) {
          consumerResult.emplace_back(std::async(std::launch::async, GetUntil<decltype(consumer)>,
-                                                consumer, data, numberConsumers, std::ref(producerCount),
-                                                std::ref(consumerCount), std::ref(consumerStop)));
+                                                consumer, data, numberConsumers, 
+                                                std::ref(producerCount), std::ref(consumerCount), 
+                                                std::ref(consumerStop)));
       }
 
       using namespace std::chrono_literals;

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -19,7 +19,7 @@ namespace QApiTests {
       producerStart.store(true);
       using namespace std::chrono_literals;
       while (!consumerStart.load()) {
-         std::this_thread::sleep_for(2ns);
+         std::this_thread::sleep_for(1us);
       }
 
       for (auto i = start; i < stop; ++i) {
@@ -43,7 +43,7 @@ namespace QApiTests {
       received.reserve(stop - start);
       consumerStart.store(true);
       while (!producerStart.load()) {
-         std::this_thread::sleep_for(2ns);
+         std::this_thread::sleep_for(1us);
       }
 
       for (auto i = start; i < stop; ++i) {
@@ -66,9 +66,6 @@ namespace QApiTests {
       using namespace std::chrono_literals;
       producerCount++;
       using namespace std::chrono_literals;
-      while (numberOfConsumers < consumerCount.load()) {
-         std::this_thread::sleep_for(2ns);
-      }
 
       StopWatch watch;
       size_t amountPushed = 0;
@@ -91,9 +88,6 @@ namespace QApiTests {
    size_t GetUntil(Receiver q, const std::string data, const size_t numberOfProducers, std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount, std::atomic<bool>& stopRunning) {
       using namespace std::chrono_literals;
       consumerCount++;
-      while (numberOfProducers < producerCount.load()) {
-         std::this_thread::sleep_for(2ns);
-      }
 
       StopWatch watch;
       size_t amountReceived = 0;
@@ -153,7 +147,8 @@ namespace QApiTests {
    }
 
    template<typename T>
-   void RunMPMC(T queue, std::string data, size_t numberProducers, size_t numberConsumers, const size_t timeToRunInSec) {
+   void RunMPMC(T queue, std::string data, size_t numberProducers,
+                size_t numberConsumers, const size_t timeToRunInSec) {
       std::atomic<size_t> producerCount{0};
       std::atomic<size_t> consumerCount{0};
       std::atomic<bool> producerStop{false};
@@ -202,7 +197,7 @@ namespace QApiTests {
       EXPECT_GE(amountConsumed + 100, amountProduced);
       std::cout << "Transaction/s: " << amountConsumed / elapsedTimeSec << std::endl;
       std::cout << "Transaction/s per consumer: " << amountConsumed / elapsedTimeSec / numberConsumers << std::endl;
-      std::cout << "Transation GByte/s: " << amountConsumed * data.size() / (1024 * 1024 * 1024) / elapsedTimeSec << std::endl;
+      std::cout << "Transation GByte/s: " << amountConsumed* data.size() / (1024 * 1024 * 1024) / elapsedTimeSec << std::endl;
    }
 
 } // Q API Tests

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -12,12 +12,13 @@ namespace QApiTests {
 
 
    template <typename Sender>
-   ResultType Push(Sender q, size_t start, size_t stop, std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
+   ResultType Push(Sender q, size_t start, size_t stop,
+                   std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
       using namespace std::chrono_literals;
+
       std::vector<std::string> expected;
       expected.reserve(stop - start);
       producerStart.store(true);
-      using namespace std::chrono_literals;
       while (!consumerStart.load()) {
          std::this_thread::sleep_for(1us);
       }
@@ -37,8 +38,10 @@ namespace QApiTests {
 
 
    template <typename Receiver>
-   ResultType Get(Receiver q, size_t start, size_t stop, std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
+   ResultType Get(Receiver q, size_t start, size_t stop,
+                  std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
       using namespace std::chrono_literals;
+
       std::vector<std::string> received;
       received.reserve(stop - start);
       consumerStart.store(true);
@@ -62,11 +65,12 @@ namespace QApiTests {
 
 
    template <typename Sender>
-   size_t PushUntil(Sender q, std::string data, const size_t numberOfConsumers, std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount, std::atomic<bool>& stopRunning) {
-      using namespace std::chrono_literals;
-      producerCount++;
+   size_t PushUntil(Sender q, std::string data, const size_t numberOfConsumers,
+                    std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount,
+                    std::atomic<bool>& stopRunning) {
       using namespace std::chrono_literals;
 
+      producerCount++;
       StopWatch watch;
       size_t amountPushed = 0;
       while (!stopRunning.load()) {
@@ -76,7 +80,6 @@ namespace QApiTests {
          }
          ++amountPushed;
       }
-
       std::ostringstream oss;
       oss << "Push Until: " << q.mStats.FlushAsString() << std::endl;
       std::cout << oss.str();
@@ -85,7 +88,9 @@ namespace QApiTests {
 
 
    template <typename Receiver>
-   size_t GetUntil(Receiver q, const std::string data, const size_t numberOfProducers, std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount, std::atomic<bool>& stopRunning) {
+   size_t GetUntil(Receiver q, const std::string data, const size_t numberOfProducers,
+                   std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount,
+                   std::atomic<bool>& stopRunning) {
       using namespace std::chrono_literals;
       consumerCount++;
 
@@ -113,8 +118,6 @@ namespace QApiTests {
       std::cout << oss.str();
       return amountReceived;
    }
-
-
 
 
    template<typename T>
@@ -146,6 +149,7 @@ namespace QApiTests {
       EXPECT_EQ(expected, received);
    }
 
+
    template<typename T>
    void RunMPMC(T queue, std::string data, size_t numberProducers,
                 size_t numberConsumers, const size_t timeToRunInSec) {
@@ -163,14 +167,16 @@ namespace QApiTests {
       producerResult.reserve(numberProducers);
 
       for (size_t i = 0; i < numberProducers; ++i) {
-         producerResult.emplace_back(std::async(std::launch::async, PushUntil<decltype(producer)>, producer, data, numberProducers,
-                                                std::ref(producerCount), std::ref(consumerCount), std::ref(producerStop)));
+         producerResult.emplace_back(std::async(std::launch::async, PushUntil<decltype(producer)>,
+                                                producer, data, numberProducers, std::ref(producerCount),
+                                                std::ref(consumerCount), std::ref(producerStop)));
       }
       std::vector<std::future<size_t>> consumerResult;
       consumerResult.reserve(numberConsumers);
       for (size_t i = 0; i < numberProducers; ++i) {
-         consumerResult.emplace_back(std::async(std::launch::async, GetUntil<decltype(consumer)>, consumer, data, numberConsumers,
-                                                std::ref(producerCount), std::ref(consumerCount), std::ref(consumerStop)));
+         consumerResult.emplace_back(std::async(std::launch::async, GetUntil<decltype(consumer)>,
+                                                consumer, data, numberConsumers, std::ref(producerCount),
+                                                std::ref(consumerCount), std::ref(consumerStop)));
       }
 
       using namespace std::chrono_literals;
@@ -195,9 +201,12 @@ namespace QApiTests {
 
       auto elapsedTimeSec = elapsedRun.ElapsedSec();
       EXPECT_GE(amountConsumed + 100, amountProduced);
-      std::cout << "Transaction/s: " << amountConsumed / elapsedTimeSec << std::endl;
-      std::cout << "Transaction/s per consumer: " << amountConsumed / elapsedTimeSec / numberConsumers << std::endl;
-      std::cout << "Transation GByte/s: " << amountConsumed* data.size() / (1024 * 1024 * 1024) / elapsedTimeSec << std::endl;
+      std::cout << "Transaction/s: "
+                << amountConsumed / elapsedTimeSec << std::endl;
+      std::cout << "Transaction/s per consumer: "
+                << amountConsumed / elapsedTimeSec / numberConsumers << std::endl;
+      std::cout << "Transation GByte/s: "
+                << amountConsumed* data.size() / (1024 * 1024 * 1024) / elapsedTimeSec << std::endl;
    }
 
 } // Q API Tests

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -1,0 +1,90 @@
+#pragma once
+#include <gtest/gtest.h>
+#include <string>
+#include <chrono>
+#include <vector>
+#include <atomic>
+#include <iostream>
+#include <future>
+
+namespace QApiTests {
+   using ResultType = std::vector<std::string>;
+
+
+   template <typename Sender>
+   ResultType Push(Sender q, size_t start, size_t stop, std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
+      using namespace std::chrono_literals;
+      std::vector<std::string> expected;
+      expected.reserve(stop - start);
+      producerStart.store(true);
+      using namespace std::chrono_literals;
+      while (!consumerStart.load()) {
+         std::this_thread::sleep_for(2ns);
+      }
+
+      for (auto i = start; i < stop; ++i) {
+         std::string value = std::to_string(i);
+         expected.push_back(value);
+         while (false == q.push(value)) {
+            std::this_thread::sleep_for(1us); // // yield is too aggressive
+         }
+      }
+      std::cout << q.mStats.FlushAsString() << std::endl;
+      return expected;
+   }
+
+
+   template <typename Receiver>
+   ResultType Get(Receiver q, size_t start, size_t stop, std::atomic<bool>& producerStart, std::atomic<bool>& consumerStart) {
+      using namespace std::chrono_literals;
+      std::vector<std::string> received;
+      received.reserve(stop - start);
+      consumerStart.store(true);
+      while (!producerStart.load()) {
+         std::this_thread::sleep_for(2ns);
+      }
+
+      for (auto i = start; i < stop; ++i) {
+         std::string value;
+         while (false == q.pop(value)) {
+            std::this_thread::sleep_for(1us); // yield is too aggressive
+         }
+         received.push_back(value);
+      }
+      std::cout << q.mStats.FlushAsString() << std::endl;
+      return received;
+   }
+
+
+
+   template<typename T>
+   void RunSPSC(T queue, const int howMany) {
+      std::atomic<bool> producerStart{false};
+      std::atomic<bool> consumerStart{false};
+
+      using namespace std;
+      using namespace chrono;
+      auto producer = std::get <QAPI::index::sender>(queue);
+      auto consumer = std::get <QAPI::index::receiver>(queue);
+
+      auto t1 = high_resolution_clock::now();
+      size_t start = 0;
+      size_t stop = howMany;
+      auto prodResult = std::async(std::launch::async, Push<decltype(producer)>,
+                                   producer, start, stop, std::ref(producerStart), std::ref(consumerStart));
+      auto consResult = std::async(std::launch::async, Get<decltype(consumer)>,
+                                   consumer, start, stop, std::ref(producerStart), std::ref(consumerStart));
+
+      auto expected = prodResult.get();
+      auto received = consResult.get();
+      auto t2 = high_resolution_clock::now();
+      auto us = duration_cast<microseconds>( t2 - t1 ).count();
+      std::cout << "Push - Pull #" << howMany << " items in: " << us  << " us" << std::endl;
+      std::cout << "Average: " << 1000 * ((float)us / (float) howMany) << " ns" << std::endl;
+
+      EXPECT_EQ(howMany, received.size());
+      EXPECT_EQ(expected, received);
+   }
+
+} // Q API Tests
+

--- a/test/QApiTests.h
+++ b/test/QApiTests.h
@@ -29,7 +29,9 @@ namespace QApiTests {
             std::this_thread::sleep_for(1us); // // yield is too aggressive
          }
       }
-      std::cout << q.mStats.FlushAsString() << std::endl;
+      std::ostringstream oss;
+      oss << "Push Until: " << q.mStats.FlushAsString() << std::endl;
+      std::cout << oss.str();
       return expected;
    }
 
@@ -51,9 +53,67 @@ namespace QApiTests {
          }
          received.push_back(value);
       }
-      std::cout << q.mStats.FlushAsString() << std::endl;
+      std::ostringstream oss;
+      oss << "GetUntil: " << q.mStats.FlushAsString() << std::endl;
+      std::cout << oss.str();
       return received;
    }
+
+
+
+   template <typename Sender>
+   size_t PushUntil(Sender q, std::string data, const size_t numberOfConsumers, std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount, std::atomic<bool>& stopRunning) {
+      using namespace std::chrono_literals;
+      producerCount++;
+      using namespace std::chrono_literals;
+      while (numberOfConsumers < consumerCount.load()) {
+         std::this_thread::sleep_for(2ns);
+      }
+
+      StopWatch watch;
+      size_t amountPushed = 0;
+      while (!stopRunning.load()) {
+         std::string value = data;
+         while (false == q.push(value) && !stopRunning.load()) {
+            std::this_thread::sleep_for(100ns); // yield is too aggressive
+         }
+         ++amountPushed;
+      }
+
+      std::ostringstream oss;
+      oss << "Push Until: " << q.mStats.FlushAsString() << std::endl;
+      std::cout << oss.str();
+      return amountPushed;
+   }
+
+
+   template <typename Receiver>
+   size_t GetUntil(Receiver q, const std::string data, const size_t numberOfProducers, std::atomic<size_t>& producerCount, std::atomic<size_t>& consumerCount, std::atomic<bool>& stopRunning) {
+      using namespace std::chrono_literals;
+      consumerCount++;
+      while (numberOfProducers < producerCount.load()) {
+         std::this_thread::sleep_for(2ns);
+      }
+
+      StopWatch watch;
+      size_t amountReceived = 0;
+      while (!stopRunning.load()) {
+         std::string value;
+         while (false == q.pop(value) && !stopRunning.load()) {
+            std::this_thread::sleep_for(100ns); // yield is too aggressive
+         }
+         if (!stopRunning.load()) {
+            EXPECT_EQ(data.size(), value.size());
+            EXPECT_FALSE(value.empty());
+            ++amountReceived;
+         }
+      }
+      std::ostringstream oss;
+      oss << "GetUntil: " << q.mStats.FlushAsString() << std::endl;
+      std::cout << oss.str();
+      return amountReceived;
+   }
+
 
 
 
@@ -84,6 +144,59 @@ namespace QApiTests {
 
       EXPECT_EQ(howMany, received.size());
       EXPECT_EQ(expected, received);
+   }
+
+   template<typename T>
+   void RunMPMC(T queue, std::string data, size_t numberProducers, size_t numberConsumers, const size_t timeToRunInSec) {
+      std::atomic<size_t> producerCount{0};
+      std::atomic<size_t> consumerCount{0};
+      std::atomic<bool> producerStop{false};
+      std::atomic<bool> consumerStop{false};
+
+
+      using namespace std;
+      using namespace std::chrono;
+      auto producer = std::get <QAPI::index::sender>(queue);
+      auto consumer = std::get <QAPI::index::receiver>(queue);
+      std::vector<std::future<size_t>> producerResult;
+      producerResult.reserve(numberProducers);
+
+      for (size_t i = 0; i < numberProducers; ++i) {
+         producerResult.emplace_back(std::async(std::launch::async, PushUntil<decltype(producer)>, producer, data, numberProducers,
+                                                std::ref(producerCount), std::ref(consumerCount), std::ref(producerStop)));
+      }
+      std::vector<std::future<size_t>> consumerResult;
+      consumerResult.reserve(numberConsumers);
+      for (size_t i = 0; i < numberProducers; ++i) {
+         consumerResult.emplace_back(std::async(std::launch::async, GetUntil<decltype(consumer)>, consumer, data, numberConsumers,
+                                                std::ref(producerCount), std::ref(consumerCount), std::ref(consumerStop)));
+      }
+
+      using namespace std::chrono_literals;
+      while (consumerCount.load() < numberConsumers && producerCount.load() < numberProducers) {
+         std::this_thread::sleep_for(1us);
+      }
+      StopWatch elapsedRun;
+      while (elapsedRun.ElapsedSec() < timeToRunInSec) {
+         std::this_thread::sleep_for(1us);
+      }
+
+      producerStop.store(true);
+      size_t amountProduced = 0;
+      for (auto& result : producerResult) {
+         amountProduced += result.get();
+      }
+      consumerStop.store(true);
+      size_t amountConsumed = 0;
+      for (auto& result : consumerResult) {
+         amountConsumed += result.get();
+      }
+
+      auto elapsedTimeSec = elapsedRun.ElapsedSec();
+      EXPECT_GE(amountConsumed + 100, amountProduced);
+      std::cout << "Transaction/s: " << amountConsumed / elapsedTimeSec << std::endl;
+      std::cout << "Transaction/s per consumer: " << amountConsumed / elapsedTimeSec / numberConsumers << std::endl;
+      std::cout << "Transation MByte/s: " << amountConsumed* data.size() / (1024 * 1024) / elapsedTimeSec << std::endl;
    }
 
 } // Q API Tests

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -4,6 +4,20 @@
 #include "RifleVampireTests.h"
 #include "Death.h"
 #include "FileIO.h"
+#include <TimeStats.h>
+#include <TriggerTimeStats.h>
+#include <g3log/g3log.hpp>
+#include <QAPI.h>
+#include <q/spsc.hpp>
+#include <q/mpmc.hpp>
+#include <future>
+#include <QueueNadoMacros.h>
+
+namespace {
+   const int kNoWaitTimeMs = 0;
+   const int kWaitTimeMs = 500;
+   const int kLongWaitTimeMs = 1500;
+}
 std::atomic<int> RifleVampireTests::mShotsDeleted;
 
 void TestDeleteString(void*, void* data) {
@@ -17,7 +31,7 @@ void TestDeleteString(void*, void* data) {
  * @param location
  */
 class TestVampire : public Vampire {
-public:
+ public:
 
    TestVampire(std::string location) : Vampire(location) {
    }
@@ -32,7 +46,7 @@ public:
  * @param location
  */
 class TestRifle : public Rifle {
-public:
+ public:
 
    TestRifle(std::string location) : Rifle(location) {
    }
@@ -60,18 +74,22 @@ std::string RifleVampireTests::GetIpcLocation() {
    return ipcLocation;
 }
 
+
 void RifleVampireTests::RifleThread(int numberOfMessages,
-        std::string& location, std::string& exampleData, int hwm,
-        int ioThreads, bool ownSocket) {
+                                    std::string& location, std::string& exampleData, int hwm,
+                                    int ioThreads, bool ownSocket) {
    Rifle rifle(location);
    rifle.SetHighWater(hwm);
    rifle.SetIOThreads(ioThreads);
    rifle.SetOwnSocket(ownSocket);
    rifle.Aim();
    std::stringstream ss;
+   TimeStats stats;
    for (int i = 0; i < numberOfMessages; i++) {
+      TriggerTimeStats trigger(stats);
       bool result = rifle.Fire(exampleData);
       if (!result) {
+         trigger.Skip();
          std::cout << "failed to fire" << std::endl;
       }
       //      std::cout << "shot fired:" << result << std::endl;
@@ -81,12 +99,14 @@ void RifleVampireTests::RifleThread(int numberOfMessages,
    while (!zctx_interrupted) {
       boost::this_thread::sleep(boost::posix_time::seconds(1));
    }
+   std::cout << "Rifle : " << stats.FlushAsString() << std::endl;
+
 
 }
 
 void RifleVampireTests::ShootStakeThread(int numberOfMessages,
-        std::string& location, std::vector<std::pair<void*, unsigned int> >& exampleData,
-        bool ownSocket) {
+      std::string& location, std::vector<std::pair<void*, unsigned int> >& exampleData,
+      bool ownSocket) {
    Rifle rifle(location);
    rifle.SetHighWater(1);
    rifle.SetIOThreads(1);
@@ -97,24 +117,26 @@ void RifleVampireTests::ShootStakeThread(int numberOfMessages,
    }
    rifle.Aim();
    std::stringstream ss;
+   TimeStats stats;
    for (int i = 0; i < numberOfMessages; i++) {
+      TriggerTimeStats trigger(stats);
       bool result = rifle.FireStakes(exampleData);
       if (!result) {
+         trigger.Skip();
          std::cout << "failed to fire" << std::endl;
       }
       //      std::cout << "shot fired:" << result << std::endl;
       //      boost::this_thread::sleep(boost::posix_time::microseconds(sleepInterval));
    }
-   //std::cout << "Done Shooting" << std::endl;
+   std::cout << "Rifle : " << stats.FlushAsString() << std::endl;
    while (!zctx_interrupted) {
       boost::this_thread::sleep(boost::posix_time::seconds(1));
    }
-
 }
 
 void RifleVampireTests::ShootZeroCopyThread(int numberOfMessages,
-        std::string& location, std::string& exampleData, int hwm, int ioThreads,
-        bool ownSocket) {
+      std::string& location, std::string& exampleData, int hwm, int ioThreads,
+      bool ownSocket) {
    Rifle rifle(location);
    rifle.SetHighWater(hwm);
    rifle.SetIOThreads(ioThreads);
@@ -125,20 +147,22 @@ void RifleVampireTests::ShootZeroCopyThread(int numberOfMessages,
    }
    rifle.Aim();
    std::stringstream ss;
+   TimeStats stats;
    for (int i = 0; i < numberOfMessages && !zctx_interrupted; i++) {
       std::string* zero = new std::string(exampleData);
+      TriggerTimeStats trigger(stats);
       bool result = rifle.FireZeroCopy(zero, zero->size(), TestDeleteString, 10000);
       if (!result) {
+         trigger.Skip();
          std::cout << "failed to fire" << std::endl;
       }
       //      std::cout << "shot fired:" << result << std::endl;
       //      boost::this_thread::sleep(boost::posix_time::microseconds(sleepInterval));
    }
-   //std::cout << "Done Shooting" << std::endl;
+   std::cout << "Rifle : " << stats.FlushAsString() << std::endl;
    while (!zctx_interrupted) {
       boost::this_thread::sleep(boost::posix_time::seconds(1));
    }
-
 }
 
 /**
@@ -151,39 +175,47 @@ void RifleVampireTests::ShootZeroCopyThread(int numberOfMessages,
  * @param ownSocket
  */
 void RifleVampireTests::VampireThread(int numberOfMessages,
-        std::string& location, std::string& exampleData, int hwm,
-        int ioThreads, bool ownSocket) {
+                                      std::string& location, std::string& exampleData, int hwm,
+                                      int ioThreads, bool ownSocket, int waitTimeMs) {
    Vampire vampire(location);
    vampire.SetHighWater(hwm);
    vampire.SetIOThreads(ioThreads);
    vampire.SetOwnSocket(ownSocket);
    ASSERT_TRUE(vampire.PrepareToBeShot());
-   for (int i=0; i < numberOfMessages && !zctx_interrupted; i++) {
+   TimeStats stats;
+   for (int i = 0; i < numberOfMessages && !zctx_interrupted; i++) {
       std::string bullet;
-      if (vampire.GetShot(bullet, 2000)) {
+      TriggerTimeStats trigger(stats);
+      if (vampire.GetShot(bullet, waitTimeMs)) {
          EXPECT_EQ(bullet, exampleData);
       } else {
+         trigger.Skip();
          //no shot in time try again
          i--;
       }
    }
+   std::cout << "Vampire : " << stats.FlushAsString() << std::endl;
    while (!zctx_interrupted) {
       boost::this_thread::sleep(boost::posix_time::seconds(1));
    }
 }
 
+
+
+
 void RifleVampireTests::StakeAVampireThread(int numberOfMessages,
-        std::string& location,
-        std::vector<std::pair<void*, unsigned int> >& exampleData,
-        int hwm, int ioThreads) {
+      std::string& location,
+      std::vector<std::pair<void*, unsigned int> >& exampleData,
+      int hwm, int ioThreads, int waitTimeMs) {
    Vampire vampire(location);
    vampire.SetHighWater(hwm);
    vampire.SetIOThreads(ioThreads);
    ASSERT_TRUE(vampire.PrepareToBeShot());
-   for (int i=0; i < numberOfMessages && !zctx_interrupted; i++) {
+   TimeStats stats;
+   for (int i = 0; i < numberOfMessages && !zctx_interrupted; i++) {
       std::vector<std::pair<void*, unsigned int> > data;
-
-      if (vampire.GetStakes(data, 2000)) {
+      TriggerTimeStats trigger(stats);
+      if (vampire.GetStakes(data, waitTimeMs)) {
          auto it = data.begin();
          auto jt = exampleData.begin();
          for (; it != data.end() && !zctx_interrupted; it++, jt++) {
@@ -191,17 +223,19 @@ void RifleVampireTests::StakeAVampireThread(int numberOfMessages,
             EXPECT_EQ(it->second, jt->second);
          }
       } else {
+         trigger.Skip();
          //no shot in time try again
          i--;
       }
    }
+   std::cout << "Vampire : " << stats.FlushAsString() << std::endl;
    while (!zctx_interrupted) {
       boost::this_thread::sleep(boost::posix_time::seconds(1));
    }
 }
 
 void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads,
-        int rifleHWM, int vampireHWM, std::string& location, int dataSize, int nShotsPerVampire, int expectedSpeed) {
+      int rifleHWM, int vampireHWM, std::string& location, int dataSize, int nShotsPerVampire, int expectedSpeed, int waitTimeMs) {
    bool bRifleOwnSocket = true;
    Rifle* rifle = new Rifle(location);
    rifle->SetHighWater(rifleHWM);
@@ -211,14 +245,14 @@ void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads
 #if RIFLE_VAMPIRE_PRODUCTION == 0
    delete rifle;
    return;
-#endif   
+#endif
 
    std::string exampleData(dataSize, 'a');
    std::vector<boost::thread*> theVampires;
    for (int i = 0; i < nVampires && !zctx_interrupted; i++) {
       boost::thread* aShooter = new boost::thread(
-              &RifleVampireTests::VampireThread, this, nShotsPerVampire, location,
-              exampleData, vampireHWM, nIOThreads, !bRifleOwnSocket);
+         &RifleVampireTests::VampireThread, this, nShotsPerVampire, location,
+         exampleData, vampireHWM, nIOThreads, !bRifleOwnSocket, waitTimeMs);
       theVampires.push_back(aShooter);
    }
    sleep(2);
@@ -226,14 +260,18 @@ void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads
    int fullSize = (nShotsPerVampire * nVampires) + ((vampireHWM * (nVampires)) * 2) + rifleHWM;
    SetExpectedTime(fullSize, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
    StartTimedSection();
+   TimeStats stats;
    for (int i = 0; i < fullSize && !zctx_interrupted; i++) {
-      if (!rifle->Fire(exampleData, 500)) {
+      TriggerTimeStats trigger(stats);
+      if (!rifle->Fire(exampleData, waitTimeMs)) {
+         trigger.Skip();
          std::cout << "Failed to fire... Vampires might all be dead..." << std::endl;
          break;
       }
    }
+   std::cout << "One Rifle --> #" << nVampires << " Vampires: " << stats.FlushAsString() << std::endl;
    for (auto it = theVampires.begin();
-           it != theVampires.end() && !zctx_interrupted; it++) {
+         it != theVampires.end() && !zctx_interrupted; it++) {
       (*it)->interrupt();
       (*it)->join();
       delete *it;
@@ -243,8 +281,130 @@ void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads
    delete rifle;
 }
 
+
+  template <typename Sender>
+   size_t Push(Sender q, int dataSize, int stop, std::atomic<bool>& stopRunning) {
+      using namespace std::chrono_literals;
+      std::vector<std::string> expected;
+      std::string exampleData(dataSize, 'a');
+      size_t pushed = 0;
+
+      using namespace std::chrono_literals;
+      for (auto i = 0; i < stop; ++i) {
+         std::string sendData = exampleData;
+         while (false == q.push(sendData)) {
+            std::this_thread::sleep_for(1us); // // yield is too aggressive
+            if (stopRunning.load()) {
+               break;
+            }
+         }
+         ++pushed;
+      }
+      std::cout << q.mStats.FlushAsString() << std::endl;
+      return pushed;
+   }
+
+  template <typename Receiver>
+   size_t Get(Receiver q, int dataSize, int stop, std::atomic<bool>& stopRunning) {
+      using namespace std::chrono_literals;
+      std::vector<std::string> expected;
+      const std::string exampleData(dataSize, 'a');
+      size_t received = 0;
+
+      using namespace std::chrono_literals;
+      for (auto i = 0; i < stop; ++i) {
+         std::string incoming;
+         while (false == q.pop(incoming)) {
+            std::this_thread::sleep_for(1us); // // yield is too aggressive
+            if (stopRunning.load()) {
+               break;
+            }
+         }
+         ++received;
+         if (!stopRunning.load()) {
+            EXPECT_EQ(exampleData, incoming);
+         }
+      }
+      std::cout << q.mStats.FlushAsString() << std::endl;
+      return received;
+   }
+
+
+
+
+void RifleVampireTests::QueueSPSCBenchmark(int dataSize, int nHowMany, int expectedSpeed) {
+
+   auto queue = QAPI::CreateQueue<spsc::flexible::circular_fifo<std::string>>(100);
+   const std::string exampleData(dataSize, 'a');
+   SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
+
+   auto producer = std::get <QAPI::index::sender>(queue);
+   auto consumer = std::get <QAPI::index::receiver>(queue);
+
+   StartTimedSection();
+   std::atomic<bool> stopRunning{false};
+
+   auto sentResult = std::async(std::launch::async, Push<decltype(producer)>,
+                                producer, dataSize, nHowMany, std::ref(stopRunning));
+   auto receivedResult = std::async(std::launch::async, Get<decltype(consumer)>,
+                                    consumer, dataSize, nHowMany, std::ref(stopRunning));
+   auto sent = sentResult.get();
+   auto received = receivedResult.get();
+   EndTimedSection();
+   EXPECT_TRUE(TimedSectionPassed());
+   EXPECT_EQ(sent, received);
+}
+
+
+void RifleVampireTests::QueueMPMCBenchmark(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed) {
+   
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(100, std::chrono::milliseconds(1));
+   const std::string exampleData(dataSize, 'a');
+   SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
+
+   auto producer = std::get <QAPI::index::sender>(queue);
+   auto consumer = std::get <QAPI::index::receiver>(queue);
+
+   StartTimedSection();
+   std::vector<std::future<size_t>> sentResult;
+   sentResult.reserve(numSenders);
+   std::vector<std::future<size_t>> receiveResult;
+   receiveResult.reserve(numReceivers);
+   std::atomic<bool> stopRunning{false};
+
+   for (int i = 0; i < numReceivers; ++i) {
+      receiveResult.emplace_back(std::async(std::launch::async, Get<decltype(consumer)>,
+                                    consumer, dataSize, nHowMany, std::ref(stopRunning)));
+   }
+
+   for (int i = 0; i < numSenders; ++i) {
+      sentResult.emplace_back(std::async(std::launch::async, Push<decltype(producer)>,
+                                    producer, dataSize, nHowMany, std::ref(stopRunning)));
+   }
+   
+
+   size_t totalSent = 0;
+   for (int i = 0; i < numSenders; ++i) {
+      totalSent = sentResult[i].get();
+   }
+
+   stopRunning.store(true);
+   size_t totalReceived = 0;
+   for (int i = 0; i < numSenders; ++i) {
+      totalReceived = receiveResult[i].get();
+   }
+   EndTimedSection();
+   EXPECT_TRUE(TimedSectionPassed());
+   EXPECT_EQ(totalSent, nHowMany); 
+   EXPECT_EQ(totalSent, totalReceived); // 100 can diff
+}
+
+
+
+
+
 void RifleVampireTests::OneRifleNVampiresStakeBenchmark(int nVampires, int nIOThreads,
-        int rifleHWM, int vampireHWM, std::string& location, int dataSize, int nShotsPerVampire, int expectedSpeed) {
+      int rifleHWM, int vampireHWM, std::string& location, int dataSize, int nShotsPerVampire, int expectedSpeed, int waitTimeMs) {
    Rifle* rifle = new Rifle(location);
    rifle->SetHighWater(rifleHWM);
    rifle->SetIOThreads(nIOThreads);
@@ -253,16 +413,17 @@ void RifleVampireTests::OneRifleNVampiresStakeBenchmark(int nVampires, int nIOTh
 #if RIFLE_VAMPIRE_PRODUCTION == 0
    delete rifle;
    return;
-#endif   
+#endif
    std::string exampleString(dataSize, 'a');
    std::vector<std::pair< void*, unsigned int> > exampleData;
    for (int i = 0; i < SIZE_OF_STAKE_BUNDLE && !zctx_interrupted; i++) {
       exampleData.push_back(make_pair(&exampleString, 1234));
    }
    std::vector<boost::thread*> theVampires;
+
    for (int i = 0; i < nVampires && !zctx_interrupted; i++) {
       boost::thread* aShooter = new boost::thread(&RifleVampireTests::StakeAVampireThread,
-              this, nShotsPerVampire, location, exampleData, vampireHWM, nIOThreads);
+            this, nShotsPerVampire, location, exampleData, vampireHWM, nIOThreads, waitTimeMs);
       theVampires.push_back(aShooter);
    }
    sleep(2);
@@ -270,15 +431,19 @@ void RifleVampireTests::OneRifleNVampiresStakeBenchmark(int nVampires, int nIOTh
    int fullSize = (nShotsPerVampire * nVampires) + ((vampireHWM * (nVampires)) * 2) + rifleHWM;
    SetExpectedTime(fullSize, exampleData.size() * sizeof (char) * SIZE_OF_STAKE_BUNDLE, expectedSpeed, 20000L);
    StartTimedSection();
+   TimeStats stats;
    for (int i = 0; i < fullSize && !zctx_interrupted; i++) {
-      if (!rifle->FireStakes(exampleData, 1500)) {
+      TriggerTimeStats trigger(stats);
+      if (!rifle->FireStakes(exampleData, waitTimeMs)) {
          std::cout << "Failed to fire at shot " << i << " of fullSize " << fullSize << std::endl;
          std::cout << " ... Vampires might all be dead..." << std::endl;
+         trigger.Skip();
          break;
       }
    }
+   std::cout << "One Rifle -->  #" << nVampires << " Vampires. " << stats.FlushAsString() << std::endl;
    for (auto it = theVampires.begin();
-           it != theVampires.end() && !zctx_interrupted; it++) {
+         it != theVampires.end() && !zctx_interrupted; it++) {
       (*it)->interrupt();
       (*it)->join();
       delete *it;
@@ -289,8 +454,8 @@ void RifleVampireTests::OneRifleNVampiresStakeBenchmark(int nVampires, int nIOTh
 }
 
 void RifleVampireTests::NRiflesOneVampireBenchmarkZeroCopy(int nRifles, int nIOThreads,
-        int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-        int nShotsPerRifle, int expectedSpeed) {
+      int rifleHWM, int vampireHWM, std::string& location, int dataSize,
+      int nShotsPerRifle, int expectedSpeed, int waitTimeMs) {
 
    bool bVampireOwnSocket = true;
    mShotsDeleted.store(0);
@@ -301,34 +466,37 @@ void RifleVampireTests::NRiflesOneVampireBenchmarkZeroCopy(int nRifles, int nIOT
    ASSERT_TRUE(vampire.PrepareToBeShot());
 #if RIFLE_VAMPIRE_PRODUCTION == 0
    return;
-#endif   
+#endif
 
    std::string exampleData(dataSize, 'z');
    std::vector<boost::thread*> theRifles;
 
    for (int i = 0; i < nRifles && !zctx_interrupted; i++) {
       boost::thread* aShooter = new boost::thread(
-              &RifleVampireTests::ShootZeroCopyThread, this, nShotsPerRifle, location,
-              exampleData, rifleHWM, nIOThreads, !bVampireOwnSocket);
+         &RifleVampireTests::ShootZeroCopyThread, this, nShotsPerRifle, location,
+         exampleData, rifleHWM, nIOThreads, !bVampireOwnSocket);
       theRifles.push_back(aShooter);
    }
 
    SetExpectedTime((nShotsPerRifle * nRifles), // numberOfPackets
-           (exampleData.size() * sizeof (char)), // packetSize
-           expectedSpeed, // RateInMbps
-           20000L); //transationsPerSection
+                   (exampleData.size() * sizeof (char)), // packetSize
+                   expectedSpeed, // RateInMbps
+                   20000L); //transationsPerSection
    StartTimedSection();
    std::string bullet;
+   TimeStats stats;
    for (int pktCount = 0; pktCount < (nShotsPerRifle * nRifles) && !zctx_interrupted; pktCount++) {
-      if (vampire.GetShot(bullet, 500)) {
+      TriggerTimeStats trigger(stats);
+      if (vampire.GetShot(bullet, waitTimeMs)) {
          EXPECT_EQ(bullet, exampleData);
       } else {
+         trigger.Skip();
          pktCount--; // Packet not received in time, try again.
       }
    }
-
+   std::cout << "#" << nRifles << " Rifles --> one Vampire. " << stats.FlushAsString() << std::endl;
    for (auto it = theRifles.begin();
-           it != theRifles.end() && !zctx_interrupted; it++) {
+         it != theRifles.end() && !zctx_interrupted; it++) {
       (*it)->interrupt();
       (*it)->join();
       delete *it;
@@ -339,8 +507,8 @@ void RifleVampireTests::NRiflesOneVampireBenchmarkZeroCopy(int nRifles, int nIOT
 }
 
 void RifleVampireTests::NRiflesOneVampireBenchmark(int nRifles, int nIOThreads,
-        int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-        int nShotsPerRifle, int expectedSpeed) {
+      int rifleHWM, int vampireHWM, std::string& location, int dataSize,
+      int nShotsPerRifle, int expectedSpeed, int waitTimeMs) {
 
    bool bVampireOwnSocket = true;
    Vampire vampire(location);
@@ -350,34 +518,38 @@ void RifleVampireTests::NRiflesOneVampireBenchmark(int nRifles, int nIOThreads,
    ASSERT_TRUE(vampire.PrepareToBeShot());
 #if RIFLE_VAMPIRE_PRODUCTION == 0
    return;
-#endif   
+#endif
 
    std::string exampleData(dataSize, 'z');
    std::vector<boost::thread*> theRifles;
 
    for (int i = 0; i < nRifles && !zctx_interrupted; i++) {
       boost::thread* aShooter = new boost::thread(
-              &RifleVampireTests::RifleThread, this, nShotsPerRifle, location,
-              exampleData, rifleHWM, nIOThreads, !bVampireOwnSocket);
+         &RifleVampireTests::RifleThread, this, nShotsPerRifle, location,
+         exampleData, rifleHWM, nIOThreads, !bVampireOwnSocket);
       theRifles.push_back(aShooter);
    }
 
    SetExpectedTime((nShotsPerRifle * nRifles), // numberOfPackets
-           (exampleData.size() * sizeof (char)), // packetSize
-           expectedSpeed, // RateInMbps
-           20000L); //transationsPerSection
+                   (exampleData.size() * sizeof (char)), // packetSize
+                   expectedSpeed, // RateInMbps
+                   20000L); //transationsPerSection
    StartTimedSection();
    std::string bullet;
+   TimeStats stats;
    for (int pktCount = 0; pktCount < (nShotsPerRifle * nRifles) && !zctx_interrupted; pktCount++) {
-      if (vampire.GetShot(bullet, 500)) {
+      TriggerTimeStats trigger(stats);
+      if (vampire.GetShot(bullet, waitTimeMs)) {
          EXPECT_EQ(bullet, exampleData);
       } else {
          pktCount--; // Packet not received in time, try again.
+         trigger.Skip();
       }
    }
 
+   std::cout << "#" << nRifles << " Rifles --> one Vampire. " << stats.FlushAsString() << std::endl;
    for (auto it = theRifles.begin();
-           it != theRifles.end() && !zctx_interrupted; it++) {
+         it != theRifles.end() && !zctx_interrupted; it++) {
       (*it)->interrupt();
       (*it)->join();
       delete *it;
@@ -388,7 +560,7 @@ void RifleVampireTests::NRiflesOneVampireBenchmark(int nRifles, int nIOThreads,
 
 TEST_F(RifleVampireTests, ipcFilesCleanedOnNormalExitRifleOwner) {
    std::string target("ipc:///rifleVampireExit");
-   std::string addressRealPath(target,target.find("ipc://")+6);
+   std::string addressRealPath(target, target.find("ipc://") + 6);
    {
       Rifle stick{target};
       {
@@ -406,7 +578,7 @@ TEST_F(RifleVampireTests, ipcFilesCleanedOnNormalExitRifleOwner) {
 
 TEST_F(RifleVampireTests, ipcFilesCleanedOnNormalExitVampireOwner) {
    std::string target("ipc:///rifleVampireExit");
-   std::string addressRealPath(target,target.find("ipc://")+6);
+   std::string addressRealPath(target, target.find("ipc://") + 6);
    {
       Vampire vamp{target};
       vamp.SetOwnSocket(true);
@@ -428,7 +600,7 @@ TEST_F(RifleVampireTests, ipcFilesCleanedOnFatal) {
    std::string target("ipc:///rifleVampireDeath");
    Rifle stick{target};
    Vampire vamp{target};
-   std::string addressRealPath(target,target.find("ipc://")+6);
+   std::string addressRealPath(target, target.find("ipc://") + 6);
    Death::SetupExitHandler();
    ASSERT_TRUE(stick.Aim());
    ASSERT_TRUE(vamp.PrepareToBeShot());
@@ -447,10 +619,12 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
-
 }
+
+
+
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCSmallSize) {
    if (geteuid() == 0) {
       std::string location = GetIpcLocation();
@@ -461,10 +635,29 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
+
+
+
+
+TEST_F(RifleVampireTests, SPSC) {
+   int dataSize = 100;
+   int howMany = 1000000;
+   int expectedSpeed = 50;
+   QueueSPSCBenchmark(dataSize, howMany, expectedSpeed);
+}
+
+TEST_F(RifleVampireTests, SPSCWithLargeTransfer) {
+   int dataSize = 65554;
+   int howMany = 200000;
+   int expectedSpeed = 1000;
+   QueueSPSCBenchmark(dataSize, howMany, expectedSpeed);
+}
+
+
 
 TEST_F(RifleVampireTests, OneRifleOneVampirePointers) {
    if (geteuid() == 0) {
@@ -476,9 +669,8 @@ TEST_F(RifleVampireTests, OneRifleOneVampirePointers) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
-
 }
 
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCSmallSize) {
@@ -492,7 +684,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCSmallSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -507,7 +699,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCSmallSizeZeroCop
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -521,7 +713,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresIPCSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -537,7 +729,7 @@ TEST_F(RifleVampireTests, OneRifleTwoVampiresPointers) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
 
    }
 
@@ -554,7 +746,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCSmallSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCSmallSizeZeroCopy) {
@@ -568,7 +760,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCSmallSizeZeroCo
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCSmallSize) {
@@ -581,7 +773,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -596,7 +788,7 @@ TEST_F(RifleVampireTests, OneRifleThreeVampiresPointers) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 
 }
@@ -611,7 +803,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresIPCSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -625,7 +817,7 @@ TEST_F(RifleVampireTests, OneRifleFourVampiresPointers) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 }
 
@@ -640,7 +832,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCSmallSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCSmallSizeZeroCopy) {
@@ -654,7 +846,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCSmallSizeZeroC
       int nShotsPerRifle = 100000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireTCPSmallSize) {
@@ -667,7 +859,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireTCPSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 3500000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -683,7 +875,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPSmallSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPSmallSizeZeroCopy) {
@@ -697,7 +889,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPSmallSizeZeroCop
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPSmallSize) {
@@ -710,7 +902,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 2000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -727,7 +919,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPSmallSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPSmallSizeZeroCopy) {
@@ -741,7 +933,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPSmallSizeZeroCo
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPSmallSize) {
@@ -754,7 +946,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -769,7 +961,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresTCPSmallSize) {
       int dataSize = 100;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 50;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -784,7 +976,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPSmallSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPSmallSizeZeroCopy) {
@@ -798,7 +990,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPSmallSizeZeroC
       int nShotsPerRifle = 350000;
       int expectedSpeed = 50;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCAvgSize) {
@@ -811,7 +1003,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -827,7 +1019,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCAvgSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCAvgSizeZeroCopy) {
@@ -841,7 +1033,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCAvgSizeZeroCopy)
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresIPCAvgSize) {
@@ -854,7 +1046,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresIPCAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -871,7 +1063,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCAvgSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCAvgSizeZeroCopy) {
@@ -885,7 +1077,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCAvgSizeZeroCopy
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCAvgSize) {
@@ -898,7 +1090,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -913,9 +1105,11 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresIPCAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
+
+ // kjellkod
 
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCAvgSize) {
    if (geteuid() == 0) {
@@ -928,7 +1122,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCAvgSize) {
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCAvgSizeZeroCopy) {
@@ -942,7 +1136,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCAvgSizeZeroCop
       int nShotsPerRifle = 100000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, OneRifleOneVampirePointerAvgSize) {
@@ -955,7 +1149,7 @@ TEST_F(RifleVampireTests, OneRifleOneVampirePointerAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 
 }
@@ -970,7 +1164,7 @@ TEST_F(RifleVampireTests, OneRifleTwoVampiresPointerAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
 
    }
 
@@ -986,7 +1180,7 @@ TEST_F(RifleVampireTests, OneRifleThreeVampiresPointerAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 
 }
@@ -1001,7 +1195,7 @@ TEST_F(RifleVampireTests, OneRifleFourVampiresPointerAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 }
 
@@ -1015,7 +1209,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireTCPAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 3500000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -1031,7 +1225,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPAvgSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPAvgSizeZeroCopy) {
@@ -1045,7 +1239,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPAvgSizeZeroCopy)
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPAvgSize) {
@@ -1058,7 +1252,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 2000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -1075,7 +1269,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPAvgSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPAvgSizeZeroCopy) {
@@ -1089,7 +1283,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPAvgSizeZeroCopy
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPAvgSize) {
@@ -1102,7 +1296,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -1117,7 +1311,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresTCPAvgSize) {
       int dataSize = 350;
       int nShotsPerVampire = 1000000;
       int expectedSpeed = 100;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -1132,7 +1326,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPAvgSize) {
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPAvgSizeZeroCopy) {
@@ -1146,7 +1340,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPAvgSizeZeroCop
       int nShotsPerRifle = 350000;
       int expectedSpeed = 100;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -1162,7 +1356,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCLargeSizeZeroCopy) {
@@ -1176,7 +1370,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireIPCLargeSizeZeroCop
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresIPCLargeSize) {
@@ -1189,7 +1383,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresIPCLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -1206,7 +1400,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCLargeSizeZeroCopy) {
@@ -1220,7 +1414,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireIPCLargeSizeZeroCo
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCLargeSize) {
@@ -1233,7 +1427,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresIPCLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -1248,7 +1442,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresIPCLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
 
@@ -1263,7 +1457,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCLargeSizeZeroCopy) {
@@ -1277,7 +1471,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireIPCLargeSizeZeroC
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, OneRifleOneVampirePointersLarge) {
@@ -1290,7 +1484,7 @@ TEST_F(RifleVampireTests, OneRifleOneVampirePointersLarge) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 
 }
@@ -1305,7 +1499,7 @@ TEST_F(RifleVampireTests, OneRifleTwoVampiresPointersLarge) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
 
    }
 
@@ -1321,7 +1515,7 @@ TEST_F(RifleVampireTests, OneRifleThreeVampiresPointersLarge) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 
 }
@@ -1336,7 +1530,7 @@ TEST_F(RifleVampireTests, OneRifleFourVampiresPointersLarge) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresStakeBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kLongWaitTimeMs);
    }
 }
 
@@ -1350,7 +1544,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireTCPLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -1366,7 +1560,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPLargeSizeZeroCopy) {
@@ -1380,7 +1574,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketOneRifleOneVampireTCPLargeSizeZeroCop
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPLargeSize) {
@@ -1393,7 +1587,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleTwoVampiresTCPLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
 
    }
 
@@ -1410,7 +1604,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPLargeSizeZeroCopy) {
@@ -1424,7 +1618,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketTwoRiflesOneVampireTCPLargeSizeZeroCo
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPLargeSize) {
@@ -1437,7 +1631,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleThreeVampiresTCPLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 
 }
@@ -1452,9 +1646,30 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleFourVampiresTCPLargeSize) {
       int dataSize = 65554;
       int nShotsPerVampire = 200000;
       int expectedSpeed = 1000;
-      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed);
+      OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
+
+
+TEST_F(RifleVampireTests, MPMC_OneToFour) {
+   int dataSize = 65554;
+   int howMany = 200000;
+   int expectedSpeed = 1000;
+   int numSenders = 1;
+   int numReceivers = 4;
+   QueueMPMCBenchmark(numSenders, numReceivers, dataSize, howMany, expectedSpeed);
+}
+
+
+TEST_F(RifleVampireTests, MPMC_FourToFour) {
+   int dataSize = 65554;
+   int howMany = 200000;
+   int expectedSpeed = 1000;
+   int numSenders = 4;
+   int numReceivers = 4;
+   QueueMPMCBenchmark(numSenders, numReceivers, dataSize, howMany, expectedSpeed);
+}
+
 
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPLargeSize) {
    if (geteuid() == 0) {
@@ -1467,7 +1682,7 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPLargeSize) {
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmark(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                 location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
 TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPLargeSizeZeroCopy) {
@@ -1481,9 +1696,10 @@ TEST_F(RifleVampireTests, VampireOwnsSocketFiveRiflesOneVampireTCPLargeSizeZeroC
       int nShotsPerRifle = 10000;
       int expectedSpeed = 1000;
       NRiflesOneVampireBenchmarkZeroCopy(nRifles, nIOThreads, rifleHWM, vampireHWM,
-              location, dataSize, nShotsPerRifle, expectedSpeed);
+                                         location, dataSize, nShotsPerRifle, expectedSpeed, kWaitTimeMs);
    }
 }
+
 TEST_F(RifleVampireTests, StopPreparingAlreadyAndJustGo) {
    std::string location = GetIpcLocation();
    Vampire vampire(location);
@@ -1710,7 +1926,7 @@ TEST_F(RifleVampireTests, CreateVampireAndRifleAndSetIOThreads) {
 
 /**
  * This should have failures because there is no one pulling messages off.
- * for some reason even with a HWM of 1 there is extra buffering going on that 
+ * for some reason even with a HWM of 1 there is extra buffering going on that
  * allows you to send more then 1 message.
  */
 TEST_F(RifleVampireTests, ShootVampireMoreThenHeCanHandle) {
@@ -1886,9 +2102,9 @@ TEST_F(RifleVampireTests, VampireBundleStakingTests) {
 
 /**
  * This should have failures because there is no one pulling messages off.
- * for some reason even with a HWM of 1 there is extra buffering going on that 
+ * for some reason even with a HWM of 1 there is extra buffering going on that
  * allows you to send more then 1 message.
- * @param 
+ * @param
  */
 TEST_F(RifleVampireTests, BringDeadVampireBackToLife) {
    std::string location = GetIpcLocation();
@@ -1930,7 +2146,7 @@ TEST_F(RifleVampireTests, BringDeadVampireBackToLife) {
 
 /**
  * Test socket ownership. Only one things can own the socket.
- * @param 
+ * @param
  */
 TEST_F(RifleVampireTests, MultileRiflesSocketOwnerTest) {
 

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -201,9 +201,6 @@ void RifleVampireTests::VampireThread(int numberOfMessages,
    }
 }
 
-
-
-
 void RifleVampireTests::StakeAVampireThread(int numberOfMessages,
       std::string& location,
       std::vector<std::pair<void*, unsigned int> >& exampleData,
@@ -308,6 +305,7 @@ void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads
       return pushed;
    }
 
+
   template <typename Receiver>
    size_t Get(Receiver q, int dataSize, int stop, std::atomic<bool>& stopRunning) {
       using namespace std::chrono_literals;
@@ -335,8 +333,6 @@ void RifleVampireTests::OneRifleNVampiresBenchmark(int nVampires, int nIOThreads
       std::cout << q.mStats.FlushAsString() << std::endl;
       return received;
    }
-
-
 
 
 void RifleVampireTests::QueueSPSCBenchmark(int dataSize, int nHowMany, int expectedSpeed) {
@@ -464,8 +460,6 @@ void RifleVampireTests::QueueMPMCBenchmark_1Minute(int numSenders, int numReceiv
    std::cout << "Transaction speed: " << ((totalReceived * dataSize / (1024 * 1024))/timecheck.ElapsedSec()) << " Mbyte/s" << std::endl; 
    EXPECT_GE(totalReceived + kQueueSize, totalSent);
 }
-
-
 
 
 void RifleVampireTests::OneRifleNVampiresStakeBenchmark(int nVampires, int nIOThreads,
@@ -674,20 +668,6 @@ TEST_F(RifleVampireTests, ipcFilesCleanedOnFatal) {
    ASSERT_FALSE(FileIO::DoesFileExist(addressRealPath));
 }
 
-/**
-*
-* The Rifle Vampire performance tests are NOT measuring correctly how much the throughput is and what the actual 
-* time it took to process them. For that reason all the performance tests are disabled with #if 0
-* 
-* For the time being they are being left in case we want to revisit similar performance tests later for the new
-* queues that we are doing.
-*
-* At that time these obsolete tests should be replaced and deleted
-*/ 
-
-
-
-
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCLargeSize) {
    if (geteuid() == 0) {
       std::string location = GetIpcLocation();
@@ -719,7 +699,16 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCSmallSize) {
 }
 
 #if 0
-
+/**
+*
+* The Rifle Vampire performance tests are NOT measuring correctly how much the throughput is and what the actual 
+* time it took to process them. For that reason all the performance tests are disabled with #if 0
+* 
+* For the time being they are being left in case we want to revisit similar performance tests later for the new
+* queues that we are doing.
+*
+* At that time these obsolete tests should be replaced and deleted
+*/ 
 
 TEST_F(RifleVampireTests, SPSC) {
    int dataSize = 100;
@@ -1878,8 +1867,6 @@ TEST_F(RifleVampireTests, ShootBlank) {
    EXPECT_FALSE(rifle.Fire(msg, 100));
    std::string bullet;
    EXPECT_FALSE(vampire.GetShot(bullet, 1));
-
-
 }
 
 TEST_F(RifleVampireTests, ShootNULL) {
@@ -2229,8 +2216,6 @@ TEST_F(RifleVampireTests, BringDeadVampireBackToLife) {
    for (int i = 0; i <= shots && !zctx_interrupted; i++) {
       EXPECT_TRUE(vampire.GetShot(bullet, 1));
    }
-
-
 }
 
 /**

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -686,7 +686,7 @@ TEST_F(RifleVampireTests, ipcFilesCleanedOnFatal) {
 */ 
 
 
-#if 0
+
 
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCLargeSize) {
    if (geteuid() == 0) {
@@ -701,7 +701,6 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCLargeSize) {
       OneRifleNVampiresBenchmark(nVampires, nIOThreads, rifleHWM, vampireHWM, location, dataSize, nShotsPerVampire, expectedSpeed, kWaitTimeMs);
    }
 }
-
 
 
 TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCSmallSize) {
@@ -719,7 +718,7 @@ TEST_F(RifleVampireTests, RifleOwnsSocketOneRifleOneVampireIPCSmallSize) {
 
 }
 
-
+#if 0
 
 
 TEST_F(RifleVampireTests, SPSC) {

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -725,7 +725,6 @@ TEST_F(RifleVampireTests, SPSCWithLargeTransfer) {
 }
 
 
-
 TEST_F(RifleVampireTests, OneRifleOneVampirePointers) {
    if (geteuid() == 0) {
       std::string location = GetIpcLocation();

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -363,7 +363,7 @@ void RifleVampireTests::QueueSPSCBenchmark(int dataSize, int nHowMany, int expec
 void RifleVampireTests::QueueMPMCBenchmark(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed) {
    
    const size_t kQueueSize = 100;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize);
+   auto queue = QAPI::CreateQueue<mpmc::flexible_lock_queue<std::string>>(kQueueSize);
    const std::string exampleData(dataSize, 'a');
    SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
 
@@ -410,7 +410,7 @@ void RifleVampireTests::QueueMPMCBenchmark(int numSenders, int numReceivers, int
 void RifleVampireTests::QueueMPMCBenchmark_1Minute(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed) {
    
    const size_t kQueueSize = 100;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize);
+   auto queue = QAPI::CreateQueue<mpmc::flexible_lock_queue<std::string>>(kQueueSize);
    const std::string exampleData(dataSize, 'a');
    SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
 

--- a/test/RifleVampireTests.cpp
+++ b/test/RifleVampireTests.cpp
@@ -367,7 +367,7 @@ void RifleVampireTests::QueueSPSCBenchmark(int dataSize, int nHowMany, int expec
 void RifleVampireTests::QueueMPMCBenchmark(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed) {
    
    const size_t kQueueSize = 100;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize, std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize);
    const std::string exampleData(dataSize, 'a');
    SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
 
@@ -414,7 +414,7 @@ void RifleVampireTests::QueueMPMCBenchmark(int numSenders, int numReceivers, int
 void RifleVampireTests::QueueMPMCBenchmark_1Minute(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed) {
    
    const size_t kQueueSize = 100;
-   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize, std::chrono::milliseconds(1));
+   auto queue = QAPI::CreateQueue<mpmc::dynamic_lock_queue<std::string>>(kQueueSize);
    const std::string exampleData(dataSize, 'a');
    SetExpectedTime(nHowMany, exampleData.size() * sizeof (char), expectedSpeed, 20000L);
 

--- a/test/RifleVampireTests.h
+++ b/test/RifleVampireTests.h
@@ -41,6 +41,7 @@ public:
 
    void QueueSPSCBenchmark(int dataSize, int nHowMany, int expectedSpeed);
    void QueueMPMCBenchmark(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed);
+   void QueueMPMCBenchmark_1Minute(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed);
    
    void OneRifleNVampiresStakeBenchmark(int nVampires, int nIOThreads,
            int rifleHWM, int vampireHWM, std::string& location, int dataSize,

--- a/test/RifleVampireTests.h
+++ b/test/RifleVampireTests.h
@@ -28,25 +28,29 @@ public:
            std::string& binding, std::vector<std::pair<void*, unsigned int> >& exampleData, 
            bool ownSocket);
    void VampireThread(int numberOfMessages, std::string& location,
-         std::string& exampleData, int hwm, int ioThreads, bool ownSocket);
+         std::string& exampleData, int hwm, int ioThreads, bool ownSocket, int waitTimeMs);
    void StakeAVampireThread(int numberOfMessages,
            std::string& location, std::vector<std::pair<void*, unsigned int> >& exampleData, 
-           int hwm, int ioThreads);
+           int hwm, int ioThreads, int waitTimeMs);
    void ShootZeroCopyThread(int numberOfMessages,
         std::string& location, std::string& exampleData,int hwm, int ioThreads, 
         bool ownSocket);
    void OneRifleNVampiresBenchmark(int nVampires, int nIOThreads,
            int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-           int nShotsPerVampire, int expectedSpeed);
+           int nShotsPerVampire, int expectedSpeed, int waitTimeMs);
+
+   void QueueSPSCBenchmark(int dataSize, int nHowMany, int expectedSpeed);
+   void QueueMPMCBenchmark(int numSenders, int numReceivers, int dataSize, int nHowMany, int expectedSpeed);
+   
    void OneRifleNVampiresStakeBenchmark(int nVampires, int nIOThreads,
            int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-           int nShotsPerVampire, int expectedSpeed);
+           int nShotsPerVampire, int expectedSpeed, int waitTimeMs);
    void NRiflesOneVampireBenchmark(int nRifles, int nIOThreads,
            int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-           int nShotsPerRifle, int expectedSpeed);
+           int nShotsPerRifle, int expectedSpeed, int waitTimeMs);
    void NRiflesOneVampireBenchmarkZeroCopy(int nRifles, int nIOThreads,
            int rifleHWM, int vampireHWM, std::string& location, int dataSize,
-           int nShotsPerRifle, int expectedSpeed);
+           int nShotsPerRifle, int expectedSpeed, int waitTimeMs);
 
    class RifleAmmo {
    public:


### PR DESCRIPTION
See also PR on StopWatch: https://github.com/logrhythm/StopWatch/pull/28

Q API + tests borrowed and modified from https://github.com/KjellKod/Q

The template powered Q API supports 
- Sender API:   push
- Receiver API: `pop`, `pop_and_wait`
   if pop_and_wait is not implemented in the `Q Type` then it will be using a template implementation approach utilizing the `pop`

- Base Q API: 
```
  usage() -> % of queue that is filled up
  size() -> used size of the queue
  capacity() -> max size possible
  capacity_free() -> unused capacity
  full() -> if queue is full
  empty() -> if queue is empty
```

As long as the `Q Type` implements the base API and the Sender Receiver API any queue can be used in the templated API. 

It is recommended that `using` or `typedef` is used in the `client code` to reduce template arguments and to keep the queue specifics changeable in one code location. 

With this setup the `creating` location in the code will have the template arguments specifics but the actual `client code` using the queues does not need to know the details and the `queue type` can change without any `client code` changes. 

  