### PR TITLE
Clean out rpmbuild dir before building

### DIFF
--- a/scripts/buildRpm.sh
+++ b/scripts/buildRpm.sh
@@ -34,6 +34,7 @@ CWD=$PWD/$PACKAGE
 DISTDIR=$CWD/dist/$PACKAGE
 PATH=$PATH:/usr/local/probe/bin:$PATH
 
+sudo rm -rf ~/rpmbuild
 rpmdev-setuptree
 cp packaging/$PACKAGE.spec ~/rpmbuild/SPECS
 rm -f $PACKAGE-$VERSION.tar.gz


### PR DESCRIPTION
These FileIO repos don't clear out the rpmbuild directory before building their rpm, so when we run the lross bootstrap script (building and installing each rpm sequentially), we install each of the previous rpms repeatedly.  